### PR TITLE
Updates netlify.toml with dummy creds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,2 @@
 [build]
   Functions = "lambda"
-  
-[context.deploy-preview.environment]
-  APP_ID="appd6s11AS3mDFW3N"
-  API_KEY="keyy6DAkYqNt0gRAO"


### PR DESCRIPTION
Updates netlify.toml to use dummy Airtable account creds for deploy previews. The Rumors Airtable account keys will be used when deploying from master.